### PR TITLE
cv2.findContours fix

### DIFF
--- a/unproject_text.py
+++ b/unproject_text.py
@@ -131,7 +131,7 @@ def get_contours(img):
 
     debug_show('threshold', work)
 
-    _, contours, hierarchy = cv2.findContours(work, cv2.RETR_CCOMP,
+    contours, hierarchy = cv2.findContours(work, cv2.RETR_CCOMP,
                                               cv2.CHAIN_APPROX_NONE)
 
     return contours, hierarchy


### PR DESCRIPTION
in the 135 line
changed this

_, contours, hierarchy = cv2.findContours(work, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)

to this

contours, hierarchy = cv2.findContours(work, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_NONE)

it's because in a previous version of opencv that function used to return 3 values, now it returns just 2 values